### PR TITLE
Fix to enable building with STATIC_UNROLL=1.

### DIFF
--- a/src/maths/matrixOps.nim
+++ b/src/maths/matrixOps.nim
@@ -2,7 +2,7 @@ import macros
 import base/globals
 import base/basicOps
 import base/wrapperTypes
-#import base/metaUtils
+import base/metaUtils
 #import globals
 #import basicOps
 #import matrixConcept

--- a/src/stagg_pv_hmc/staghmc_spv.nim
+++ b/src/stagg_pv_hmc/staghmc_spv.nim
@@ -834,7 +834,7 @@ proc fforce(s: Staggered; f: auto; gf: auto;
          discard t[mu] ^* psi
 
       # Create variable for convenience
-      let n = psi[0].len
+      const n = psi[0].len
 
       # Calculate outer product for Dslash
       # Start thread block


### PR DESCRIPTION
This small patch allows staghmc_spv target to build with the environment setting STATIC_UNROLL=1.